### PR TITLE
fix(otp-component): not able to delete by pressing backspace

### DIFF
--- a/src/components/OtpInputs/OtpInputs.tsx
+++ b/src/components/OtpInputs/OtpInputs.tsx
@@ -36,7 +36,7 @@ const OtpInputs = ({
   const inputRef = useRef<HTMLInputElement[]>([]);
 
   const handleChange = (index: number, value: string) => {
-    const regex = /^[0-9]+$/;
+    const regex = /^[0-9]*$/;
     if(!regex.test(value))return;
     const otpCopy = [...otp];
     otpCopy[index]= value


### PR DESCRIPTION
This regex /^[0-9]+$/ does not allow empty string(''). Hence delete functionality was not working after the recent change. Now updated the regex to /^[0-9]*$/ and the delete feature works as expected since this regex allows empty string.